### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "taro-ui-vue3",
   "version": "1.0.0-alpha.8",
   "description": "Taro UI Rewritten in Vue 3.0",
+  "main:h5": "dist/index.esm.js",
+  "browser": "dist/index.umd.js",
   "module": "dist/index.esm.js",
   "main": "dist/index.js",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "taro-ui-vue3",
   "version": "1.0.0-alpha.8",
   "description": "Taro UI Rewritten in Vue 3.0",
-  "browser": "dist/index.umd.js",
   "module": "dist/index.esm.js",
   "main": "dist/index.js",
   "source": "src/index.ts",


### PR DESCRIPTION
在项目中使用，webpack会优先使用browser，即便是import也是用到了index.umd.js，导致AtAccordion组件点击抛错。
index.umd.js?aa1b:42 Uncaught (in promise) TypeError: Taro__default.default.createSelectorQuery is not a function
    at delayQuerySelector (index.umd.js?aa1b:42)