### PR TITLE
feat(virtual-scroll): 新增 viewport 属性

### DIFF
--- a/src/components/virtual-scroll/index.ts
+++ b/src/components/virtual-scroll/index.ts
@@ -28,6 +28,10 @@ const AtVirtualScroll = defineComponent({
       type: [Number, String] as PropType<AtVirtualScrollProps['bench']>,
       default: 0,
     },
+    viewport: {
+      type: [Number, String] as PropType<AtVirtualScrollProps['viewport']>,
+      default: 5,
+    },
     itemHeight: {
       type: [Number, String] as PropType<AtVirtualScrollProps['itemHeight']>,
       required: true,
@@ -66,6 +70,10 @@ const AtVirtualScroll = defineComponent({
       return parseInt(`${props.bench}`, 10)
     })
 
+    const __viewport = computed<number>(() => {
+      return parseInt(`${props.viewport}`, 10) - 1
+    })
+
     const __itemHeight = computed<number>(() => {
       return parseInt(`${props.itemHeight}`, 10)
     })
@@ -75,7 +83,7 @@ const AtVirtualScroll = defineComponent({
     })
 
     const lastToRender = computed<number>(() => {
-      return Math.min(props.items.length, last.value + __bench.value)
+      return Math.min(props.items.length, last.value + __viewport.value + __bench.value)
     })
 
     const measurableStyles = computed<Record<string, string>>(() => {

--- a/src/pages/advanced/virtual-scroll/index.vue
+++ b/src/pages/advanced/virtual-scroll/index.vue
@@ -63,7 +63,7 @@
     </panel>
     <panel title="触底和触顶事件">
       <at-virtual-scroll
-        bench="10"
+        bench="5"
         height="300"
         :item-height="directoryItemHeight"
         :items="directoryItems"

--- a/types/virtual-scroll.d.ts
+++ b/types/virtual-scroll.d.ts
@@ -3,11 +3,16 @@ import AtComponent from './base'
 
 export interface AtVirtualScrollProps extends AtComponent {
   /*
-  * 列表单项渲染提前量，即在可视区域之外提前渲染的列表单项数量。
+  * 列表渲染提前量，即在可视区域之外提前渲染的列表行数。
   * 值设置得越高，快速滚动时出现白屏的概率就越小；相应地，每次滚动的性能会变得越差。
   * @default 0
   */
   bench?: number | string;
+  /*
+  * 可视区域渲染的列表行数
+  * @default 5
+  */
+  viewport?: number | string;
   /*
   * 列表单项高度，用于计算列表单项的 top 样式值，单位 px。必填
   * @default undefined


### PR DESCRIPTION
本 PR 旨在为 `AtVirtualScroll` 新增 `viewport` 属性，即可视区域渲染的列表行数，这样用户可自行决定在可视区域应该渲染多少行。